### PR TITLE
BlockPrefix should return an string, let AbstractType take care of it

### DIFF
--- a/src/UserBundle/Form/Type/LoginType.php
+++ b/src/UserBundle/Form/Type/LoginType.php
@@ -30,8 +30,4 @@ class LoginType extends AbstractType
             ])
         ;
     }
-
-    public function getBlockPrefix(): void
-    {
-    }
 }


### PR DESCRIPTION
With a block prefix to null it is not compatible with Symfony 5