### PR TITLE
Use the dependency injection to inject the AuthenticationUtils service

### DIFF
--- a/src/UserBundle/Controller/SecurityController.php
+++ b/src/UserBundle/Controller/SecurityController.php
@@ -15,13 +15,8 @@ class SecurityController extends AbstractController
     /**
      * @Route("/login", name="dh_userbundle_login", methods={"GET", "POST"})
      */
-    public function login(): Response
+    public function login(AuthenticationUtils $authenticationUtils): Response
     {
-        /**
-         * @var AuthenticationUtils
-         */
-        $authenticationUtils = $this->get('security.authentication_utils');
-
         // get the login error if there is one
         $lastError = $authenticationUtils->getLastAuthenticationError();
         if (null !== $lastError) {

--- a/src/UserBundle/Resources/config/services.yaml
+++ b/src/UserBundle/Resources/config/services.yaml
@@ -13,6 +13,8 @@ services:
         public: true
 
     DH\UserBundle\Controller\SecurityController:
+        tags:
+            - 'controller.service_arguments'
         calls:
             - method: setContainer
               arguments:


### PR DESCRIPTION
When upgrading symfony to 5.2, i've got this error 
![image](https://user-images.githubusercontent.com/23059458/110336686-63b6c600-8025-11eb-90ac-24789f23fb01.png)

So, i tagged the SecurityController with the `controller.service_arguments` to inject the `AuthenticationUtils` service to the login method